### PR TITLE
Fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#oscar-web
+# oscar-web
 
 oscar-web is a web-interface for simple interaction with the OpenStreetMap search engine [oscar](https://github.com/dbahrdt/oscar). The goal is to provide an easy to use interface and allowing
 to present every search result, independent of size, on the map using clustering.
@@ -7,7 +7,7 @@ To search for specific institutions like restaurants, parks or hotels the corres
 isn't capable of mapping something like "pizza" to "cuisine=pizza". To prevent that a user needs to know such tags, frequently used ones are integrated in a search menu so that they can be easily added to the query. If a corresponding tag is not in the menu
 an additional search field, that queries the [taginfo](http://taginfo.openstreetmap.org/) database, can be used.
 
-#Functionalities
+## Functionalities
 
 - search in the viewport or in the global OSM dataset
 - search within user defined polygons or paths
@@ -16,7 +16,8 @@ an additional search field, that queries the [taginfo](http://taginfo.openstreet
 - help system that supports the user defining advanced queries
 - flickr integration to enhance search results
 
-#Used libraries
+## Used libraries
+
 - [dagre-d3](https://github.com/cpettitt/dagre-d3)
 - [sidebar-v2](https://github.com/Turbo87/sidebar-v2)
 - [leaflet](http://leafletjs.com/)


### PR DESCRIPTION
[GitHub flavored markdown](https://help.github.com/articles/basic-writing-and-formatting-syntax/) requires a space after `#`. The repository name is h1, the others h2.

This PR fixes both.